### PR TITLE
[Feature] Bid Model + Functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,3 +81,5 @@ end
 gem "devise" 
 
 
+
+gem "active_model_serializers", "~> 0.10.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.14)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.0.8)
       activesupport (= 7.0.8)
       globalid (>= 0.3.6)
@@ -83,6 +88,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -124,6 +131,7 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.2.1)
       railties (>= 6.0.0)
+    jsonapi-renderer (0.2.2)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -260,6 +268,7 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.14)
   bootsnap
   byebug
   capybara

--- a/app/controllers/api/v1/bid_controller.rb
+++ b/app/controllers/api/v1/bid_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::BidController < ApplicationController
+  def create
+    bid = Bid.create!(bid_params.merge(user: current_user))
+    if bid
+      render json: bid
+    else
+      render json: bid.errors
+    end
+  end
+
+  private
+
+  def bid_params
+    params.permit(:amount, :item_id)
+  end
+end

--- a/app/controllers/api/v1/item_controller.rb
+++ b/app/controllers/api/v1/item_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::ItemController < ApplicationController
   end
 
   def show
-    render json: @item
+    render json: @item, serializer: ItemSerializer
   end
 
   private

--- a/app/javascript/components/CreateItem.tsx
+++ b/app/javascript/components/CreateItem.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { createItem } from '../services';
+import { Link } from 'react-router-dom';
 
 export default (): JSX.Element => {
 
@@ -36,7 +37,7 @@ export default (): JSX.Element => {
                 <button onClick={handleSubmit} className='btn btn-lg custom-button mt-4'>Create Item</button>
             </div>
             <div>
-                <button onClick={() => window.open(`/`)} className='btn btn-lg custom-button mt-2'>Navigate Home</button>
+                <Link to='/' className='btn btn-lg custom-button mt-2'>Navigate Home</Link>
             </div>
         </div>
     );

--- a/app/javascript/components/Item.tsx
+++ b/app/javascript/components/Item.tsx
@@ -26,6 +26,8 @@ export default (): JSX.Element => {
         <div>
             <h2 className='text-center'>Product: {item.name}</h2>
             <p className='text-center'>Description: {item.description}</p>
+            <p className='text-center'>Current Bid: <strong>${item.latest_bid_amount}</strong></p>
+            <p className='text-center'>Current Winner: {item.latest_bid_user}</p>
             <div className='d-flex justify-content-center'>
                 <Link to='/' className='btn btn-lg custom-button mt-2'>Navigate Home</Link>
             </div>

--- a/app/javascript/components/Item.tsx
+++ b/app/javascript/components/Item.tsx
@@ -8,11 +8,28 @@ export default (): JSX.Element => {
 
     const { id } = useParams();
     const [item, setItem] = useState<Item | null>();
+    const [auctionStillActive, setAuctionStillActive] = useState<boolean>(false);
+    const [remainingAuctionTime, setRemainingAuctionTime] = useState<number>(0);
 
     useEffect(() => {
         const fetchItem = async (): Promise<void> => {
-            const item = await getItem(Number(id));
+            const item = await getItem(Number(id)) as Item;
+            setAuctionStillActive(item.auction_active);
             setItem(item);
+
+            if (item.auction_active) {
+                const timer = setInterval(() => {
+                    const secondsPassedSinceCreation = Math.floor((new Date().getTime() - new Date(item.created_at).getTime()) / 1000);
+                    const secondsRemaining = 30 - secondsPassedSinceCreation;
+                    console.log('seconds remaining', secondsRemaining);
+                    setRemainingAuctionTime(secondsRemaining);
+
+                    if (secondsRemaining <= 0) {
+                        clearInterval(timer);
+                        setAuctionStillActive(false);
+                    };
+                }, 1000);
+            };
         };
 
         fetchItem();
@@ -24,6 +41,9 @@ export default (): JSX.Element => {
 
     return(
         <div>
+            {
+               auctionStillActive && <h2 className='text-center'>Time to Bid Remaining: {remainingAuctionTime} seconds</h2>
+            }
             <h2 className='text-center'>Product: {item.name}</h2>
             <p className='text-center'>Description: {item.description}</p>
             <p className='text-center'>Current Bid: <strong>${item.latest_bid_amount}</strong></p>

--- a/app/javascript/components/Item.tsx
+++ b/app/javascript/components/Item.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { getItem } from '../services';
 import { Item } from '../types/item';
+import { Link } from 'react-router-dom';
 
 export default (): JSX.Element => {
 
@@ -25,6 +26,9 @@ export default (): JSX.Element => {
         <div>
             <h2 className='text-center'>Product: {item.name}</h2>
             <p className='text-center'>Description: {item.description}</p>
+            <div className='d-flex justify-content-center'>
+                <Link to='/' className='btn btn-lg custom-button mt-2'>Navigate Home</Link>
+            </div>
         </div>
     );
 };

--- a/app/javascript/components/Items.tsx
+++ b/app/javascript/components/Items.tsx
@@ -35,7 +35,7 @@ export default () => {
                         return <tr>
                             <td className='border'>
                                 <Link to={`/item/${item.id}`}>
-                                    {item.name}
+                                    {item.name}{item.auction_active ? ' (ACTIVE AUCTION!!!)' : ''}
                                 </Link>
                             </td>
                             <td className='border'>{item.description}</td>

--- a/app/javascript/components/Items.tsx
+++ b/app/javascript/components/Items.tsx
@@ -17,7 +17,7 @@ export default () => {
         };
 
         fetchItem();
-    });
+    }, []);
 
     if (items.length === 0) {
         return <></>;

--- a/app/javascript/components/Items.tsx
+++ b/app/javascript/components/Items.tsx
@@ -33,7 +33,11 @@ export default () => {
                 {
                     items.map((item: Item) => {
                         return <tr>
-                            <td className='border'>{item.name}</td>
+                            <td className='border'>
+                                <Link to={`/item/${item.id}`}>
+                                    {item.name}
+                                </Link>
+                            </td>
                             <td className='border'>{item.description}</td>
                         </tr>
                     })

--- a/app/javascript/types/item.ts
+++ b/app/javascript/types/item.ts
@@ -7,4 +7,5 @@ export type Item = {
     updated_at: string,
     latest_bid_amount: number,
     latest_bid_user: string,
+    auction_active: boolean,
 };

--- a/app/javascript/types/item.ts
+++ b/app/javascript/types/item.ts
@@ -5,4 +5,6 @@ export type Item = {
     user_id: number,
     created_at: string,
     updated_at: string,
+    latest_bid_amount: number,
+    latest_bid_user: string,
 };

--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -1,0 +1,4 @@
+class Bid < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -4,6 +4,18 @@ class Bid < ApplicationRecord
 
   validate :auction_active?, on: :create
 
+  def minimum_bid
+    current_bid = item.latest_bid&.amount || 0
+    tmp_bid = current_bid
+    min_increment = 1
+    while (tmp_bid >= 100) do
+      min_increment = min_increment * 10
+      tmp_bid = tmp_bid / 10
+    end
+
+    current_bid + min_increment
+  end
+
   private
 
   def auction_active?

--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -3,6 +3,7 @@ class Bid < ApplicationRecord
   belongs_to :item
 
   validate :auction_active?, on: :create
+  validate :meets_minimum_bid?, on: :create
 
   def minimum_bid
     current_bid = item.latest_bid&.amount || 0
@@ -21,6 +22,12 @@ class Bid < ApplicationRecord
   def auction_active?
     unless item.auction_active?
       errors.add(:auction_ended, "the auction has closed")
+    end
+  end
+
+  def meets_minimum_bid?
+    unless minimum_bid <= amount
+      errors.add(:failed_minimum_bed, "bid is too low")
     end
   end
 end

--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -1,4 +1,14 @@
 class Bid < ApplicationRecord
   belongs_to :user
   belongs_to :item
+
+  validate :auction_active?, on: :create
+
+  private
+
+  def auction_active?
+    unless item.auction_active?
+      errors.add(:auction_ended, "the auction has closed")
+    end
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :user
+  has_many :bids
 
   validates :name, presence: true
   validate :no_active_auction?, on: :create
@@ -11,6 +12,10 @@ class Item < ApplicationRecord
   def self.is_active_auction?
     return false if self.count == 0
     self.latest_item.created_at + 30.seconds > Time.now
+  end
+
+  def latest_bid
+    bids.order(amount: :desc).first
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,6 +18,10 @@ class Item < ApplicationRecord
     bids.order(amount: :desc).first
   end
 
+  def auction_active?
+    created_at + 30.seconds > Time.now
+  end
+
   private
 
   def no_active_auction?

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,11 @@
+class ItemSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description, :user_id, :created_at, :updated_at, :latest_bid_amount, :latest_bid_user
+
+    def latest_bid_amount
+      object.latest_bid&.amount || 0
+    end
+
+    def latest_bid_user
+      object.latest_bid&.user&.email || ''
+    end
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,5 +1,5 @@
 class ItemSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :user_id, :created_at, :updated_at, :latest_bid_amount, :latest_bid_user
+  attributes :id, :name, :description, :user_id, :created_at, :updated_at, :latest_bid_amount, :latest_bid_user, :auction_active
 
     def latest_bid_amount
       object.latest_bid&.amount || 0
@@ -7,5 +7,9 @@ class ItemSerializer < ActiveModel::Serializer
 
     def latest_bid_user
       object.latest_bid&.user&.email || ''
+    end
+
+    def auction_active
+      object.auction_active?
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      post 'bid/create'
       get 'item/index'
       post 'item/create'
       get 'item/show/:id', to: 'item#show'

--- a/db/migrate/20240130001556_create_bids.rb
+++ b/db/migrate/20240130001556_create_bids.rb
@@ -1,0 +1,11 @@
+class CreateBids < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bids do |t|
+      t.integer :amount, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_26_004759) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_30_001556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bids", force: :cascade do |t|
+    t.integer "amount", null: false
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_bids_on_item_id"
+    t.index ["user_id"], name: "index_bids_on_user_id"
+  end
 
   create_table "items", force: :cascade do |t|
     t.string "name"
@@ -44,5 +54,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_26_004759) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bids", "items"
+  add_foreign_key "bids", "users"
   add_foreign_key "items", "users"
 end

--- a/spec/controllers/api/v1/bid_controller_spec.rb
+++ b/spec/controllers/api/v1/bid_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::BidController, type: :controller do
+
+  describe "POST #create" do
+    let!(:user) { create(:user) }
+    let!(:item) { create(:item, user: user) }
+    before { allow(controller).to receive(:current_user) { user } }
+
+    it "returns http success" do
+      params = {amount: 1, item_id: item.id}
+      expect { post :create, params: params }.to change{ Bid.count }.by(1)
+    end
+  end
+end

--- a/spec/controllers/api/v1/item_controller_spec.rb
+++ b/spec/controllers/api/v1/item_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Api::V1::ItemController, type: :controller do
 
     it "returns an array of items" do
       get :index
-      expect(JSON.parse(response.body)).to eq([item.as_json])
+      expected_response = item.as_json.merge({"latest_bid_amount" => 0, "latest_bid_user" => ''})
+      expect(JSON.parse(response.body)).to eq([expected_response])
     end
   end
 
@@ -33,7 +34,8 @@ RSpec.describe Api::V1::ItemController, type: :controller do
 
     it "returns http success" do
       get :show, params: { id: item.id }
-      expect(JSON.parse(response.body)).to eq(item.as_json)
+      expected_response = item.as_json.merge({"latest_bid_amount" => 0, "latest_bid_user" => ''})
+      expect(JSON.parse(response.body)).to eq(expected_response)
     end
   end
 end

--- a/spec/controllers/api/v1/item_controller_spec.rb
+++ b/spec/controllers/api/v1/item_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::ItemController, type: :controller do
 
     it "returns an array of items" do
       get :index
-      expected_response = item.as_json.merge({"latest_bid_amount" => 0, "latest_bid_user" => ''})
+      expected_response = item.as_json.merge({"latest_bid_amount" => 0, "latest_bid_user" => '', "auction_active" => true})
       expect(JSON.parse(response.body)).to eq([expected_response])
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe Api::V1::ItemController, type: :controller do
 
     it "returns http success" do
       get :show, params: { id: item.id }
-      expected_response = item.as_json.merge({"latest_bid_amount" => 0, "latest_bid_user" => ''})
+      expected_response = item.as_json.merge({"latest_bid_amount" => 0, "latest_bid_user" => '', "auction_active" => true})
       expect(JSON.parse(response.body)).to eq(expected_response)
     end
   end

--- a/spec/factories/bids.rb
+++ b/spec/factories/bids.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :bid do
+    amount 1
+    user nil
+    item nil
+  end
+end

--- a/spec/models/bid_spec.rb
+++ b/spec/models/bid_spec.rb
@@ -51,4 +51,31 @@ RSpec.describe Bid, type: :model do
       expect(failed_bid.errors[:auction_ended]).not_to be_empty
     end
   end
+
+  describe '#minimum_bid' do
+    it 'if the current bid is less than 10, the next bed must be current bid + 1' do
+      bid = create(:bid, item: product, user: bidder, amount: 5)
+      expect(bid.minimum_bid).to eq(bid.amount + 1)
+    end
+
+    it 'if the current bid is less than 100, the next bed must be current bid + 1' do
+      bid = create(:bid, item: product, user: bidder, amount: 55)
+      expect(bid.minimum_bid).to eq(bid.amount + 1)
+    end
+
+    it 'if the current bid is 100, the next bed must be 110' do
+      bid = create(:bid, item: product, user: bidder, amount: 100)
+      expect(bid.minimum_bid).to eq(110)
+    end
+
+    it 'if the current bid is less than 1000 but greater than 100, the next bed must be current bid + 10' do
+      bid = create(:bid, item: product, user: bidder, amount: 155)
+      expect(bid.minimum_bid).to eq(bid.amount + 10)
+    end
+
+    it 'if the current bid is less than 10000 but greater than 1000, the next bed must be current bid + 100' do
+      bid = create(:bid, item: product, user: bidder, amount: 1555)
+      expect(bid.minimum_bid).to eq(bid.amount + 100)
+    end
+  end
 end

--- a/spec/models/bid_spec.rb
+++ b/spec/models/bid_spec.rb
@@ -50,6 +50,19 @@ RSpec.describe Bid, type: :model do
       expect(failed_bid).to be_invalid
       expect(failed_bid.errors[:auction_ended]).not_to be_empty
     end
+
+    it 'throws an error when trying to create a bid that is too little' do
+      Bid.create(user: bidder, amount: 155, item: product)
+      failed_bid = Bid.new(user: bidder, amount: 160, item: product)
+      expect(failed_bid).to be_invalid
+      expect(failed_bid.errors[:failed_minimum_bed]).not_to be_empty
+    end
+
+    it 'successfully creates a bid that is within the timeframe AND meets the minimum bid' do
+      Bid.create(user: bidder, amount: 155, item: product)
+      successful_second_bid = Bid.create(user: bidder, amount: 166, item: product)
+      expect(successful_second_bid.valid?).to be(true)
+    end
   end
 
   describe '#minimum_bid' do

--- a/spec/models/bid_spec.rb
+++ b/spec/models/bid_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Bid, type: :model do
+  let!(:owner) { create(:user) }
+  let!(:product) { create(:item, user: owner) }
+  let!(:bidder) { create(:user) }
+
+  describe '#amount' do
+    let(:bid) { create(:bid, item: product, user: bidder, amount: 1) }
+
+    it 'is valid when an amount is set' do
+      expect(bid.valid?).to eq(true)
+    end
+
+    it 'is not valid when an amount is NOT set' do
+      expect { bid.update(amount: nil) }.to raise_error(ActiveRecord::NotNullViolation)
+    end
+  end
+
+  describe '#user' do
+    let(:bid) { create(:bid, item: product, user: bidder, amount: 1) }
+
+    it 'is valid when a user is set' do
+      expect(bid.valid?).to eq(true)
+    end
+
+    it 'is not valid when a user is NOT set' do
+      bid.update(user: nil)
+      expect(bid.valid?).to eq(false)
+    end
+  end
+
+  describe '#item' do
+    let(:bid) { create(:bid, item: product, user: bidder, amount: 1) }
+
+    it 'is valid when an item is set' do
+      expect(bid.valid?).to eq(true)
+    end
+
+    it 'is not valid when an item is NOT set' do
+      bid.update(item: nil)
+      expect(bid.valid?).to eq(false)
+    end
+  end
+end

--- a/spec/models/bid_spec.rb
+++ b/spec/models/bid_spec.rb
@@ -42,4 +42,13 @@ RSpec.describe Bid, type: :model do
       expect(bid.valid?).to eq(false)
     end
   end
+
+  describe '#create' do
+    it 'throws an error when trying to create a bid after the auction has ended' do
+      product.update(created_at: Time.now - 31)
+      failed_bid = Bid.new(user: bidder, amount: 1, item: product)
+      expect(failed_bid).to be_invalid
+      expect(failed_bid.errors[:auction_ended]).not_to be_empty
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -55,4 +55,17 @@ RSpec.describe Item, type: :model do
       expect(failed_item.errors[:active_auction]).not_to be_empty
     end
   end
+
+  describe '#latest_bid' do
+    let!(:user) { create(:user) }
+    let!(:bidder) { create(:user) }
+    let!(:bidder_2) { create(:user) }
+    let!(:item) { create(:item, user: user) }
+    let!(:bid) { create(:bid, item: item, user: bidder, amount: 1) }
+    let!(:bid_2) { create(:bid, item: item, user: bidder_2, amount: 11) }
+
+    it 'displays the latest bid' do
+      expect(item.latest_bid).to eq(bid_2)
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -68,4 +68,18 @@ RSpec.describe Item, type: :model do
       expect(item.latest_bid).to eq(bid_2)
     end
   end
+
+  describe '#auction_active?' do
+    let!(:user) { create(:user) }
+    let!(:item) { create(:item, user: user) }
+
+    it 'returns true when auction is still running' do
+      expect(item.auction_active?).to eq(true)
+    end
+
+    it 'returns false when auction finishes running' do
+      item.update(created_at: Time.now - 31)
+      expect(item.auction_active?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
- add link to our home page from the Item page
- add link from home page to each Item in our table
- avoid reload on CreateItem component by changing Button to Link Element
- run ```rails g model Bid amount:integer user:references item:references``` to generate our Bid model
- creates associated tests ensuring an amount, user and item is set
- adds a method to grab the latest_bid off our item model and adds associated spec
- add serializer gem so we can pull additional properties easily, follow this guide: https://dev.to/nkulik94/using-active-model-serializer-4ffg
- create an ItemSerializer to grab current bidder info and created associated tests
- major bug fix preventing endlessly calling backend by passing dependency matrix
- adds new method to model and serializes #auction_active to determine on frontend if bidding is still active adds this to our type
- display current winning amount and winner
- add frontend calculation to determine whether the auction is still running and how long it will remain running for
- adds validation #auction_active? that ensures we don't create bids after the auction has ended on the backend (already have backend checks but this increases security for user's creating requests with tools like PostMan)
- adds a method to grab the next minimum_bid off -- this could potentially be moved onto the Item model and would make more sense there but for simplicity we will leave it here
- adds several test cases
- adds a validation #meets_minimum_bid? to ensure we meet the minimum bid
- adds spec tests ensuring the minimum is met before creation
- add create route for our Bid and associated specs
- permit params for our amount and item id